### PR TITLE
Token blacklist

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ gunicorn
 gevent
 gevent-websocket
 requests
+blinker

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ flask-mongoengine
 pyyaml
 python-dateutil
 pyjwt
+uuid
 Flask-Mail
 celery
 Flask-Bcrypt

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -158,6 +158,13 @@ def create_app():
         from src.common.init_defaults import init_default_users
         init_default_users()
 
+        """ Create expiration index for TokenBlacklist """
+        from src.models.tokenblacklist import TokenBlacklist
+        TokenBlacklist.create_index("created_at", expireAfterSeconds=(
+            60 * app.config.get("TOKEN_EXPIRATION_MINUTES")
+            + app.config.get("TOKEN_EXPIRATION_SECONDS")
+        ), background=True)
+
     return app, celery
 
 

--- a/src/api/club_events.py
+++ b/src/api/club_events.py
@@ -10,7 +10,6 @@
 """
 from flask import request
 from src.api import Blueprint
-from mongoengine.errors import ValidationError
 from werkzeug.exceptions import BadRequest
 import dateutil.parser
 from datetime import datetime, timedelta

--- a/src/api/events.py
+++ b/src/api/events.py
@@ -12,7 +12,7 @@
 
 from flask import request
 from src.api import Blueprint
-from mongoengine.errors import ValidationError, NotUniqueError
+from mongoengine.errors import NotUniqueError
 from werkzeug.exceptions import BadRequest, NotFound, Conflict
 from src.models.event import Event
 from src.models.sponsor import Sponsor

--- a/src/api/live_updates.py
+++ b/src/api/live_updates.py
@@ -14,7 +14,7 @@
         delete_update(id: int)
 
 """
-from flask import Blueprint, request, current_app as app
+from flask import Blueprint, request
 from werkzeug.exceptions import BadRequest, NotFound
 from src.common.decorators import authenticate, privileges
 from flask_socketio import Namespace, emit

--- a/src/common/decorators.py
+++ b/src/common/decorators.py
@@ -10,10 +10,10 @@
 """
 from flask import request, current_app
 from functools import wraps
-from werkzeug.exceptions import Forbidden, Unauthorized, NotFound
+from werkzeug.exceptions import Forbidden, Unauthorized
 from src.models.user import User, ROLES
 from src.models.tokenblacklist import TokenBlacklist
-import jwt
+from src.common.jwt import decode_jwt
 
 
 def privileges(roles):
@@ -59,9 +59,7 @@ def authenticate(f):
         if not token:
             raise Unauthorized("User is not signed in!")
 
-        decoded_token = jwt.decode(token,
-                                   current_app.config.get("SECRET_KEY"),
-                                   algorithms=["HS256"])
+        decoded_token = decode_jwt(token)
 
         fromBL = TokenBlacklist.findOne(
             jti=decoded_token["jti"],
@@ -71,10 +69,12 @@ def authenticate(f):
         if not fromBL:
             raise Unauthorized("User is not signed in!")
 
-        data = User.decode_auth_token(token)
-        user = User.objects(username=data).first()
+        user = User.objects(username=decoded_token["sub"]).first()
 
-        if not user or fromBL.user == user:
+        if not user:
+            raise Forbidden()
+
+        if user.username != fromBL.user.username:
             raise Forbidden()
 
         return f(user, *args, **kwargs)

--- a/src/common/jwt.py
+++ b/src/common/jwt.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""
+    src.common.jwt
+    ~~~~~~~~~~~~~~
+    Helper functions for JWT tokens
+
+"""
+import jwt
+import uuid
+from flask import current_app
+from werkzeug.exceptions import Unauthorized
+from datetime import datetime
+
+
+def encode_jwt(exp: datetime, sub: str):
+    return jwt.encode(
+        {
+            "exp": exp,
+            "iat": datetime.utcnow(),
+            "sub": sub,
+            "jti": str(uuid.uuid4()),
+            "iss": current_app.config.get("BACKEND_URL")
+        },
+        current_app.config.get("SECRET_KEY"),
+        algorithm="HS256"
+    )
+
+
+def decode_jwt(token: str) -> dict:
+    try:
+        return jwt.decode(
+            token,
+            current_app.config.get("SECRET_KEY"),
+            options={
+                "require": ["exp", "iat", "jti", "sub", "iss"],
+                "verify_iss": True
+            },
+            algorithms=["HS256"],
+            issuer=current_app.config.get("BACKEND_URL")
+        )
+    except jwt.ExpiredSignatureError:
+        raise Unauthorized()
+    except jwt.InvalidTokenError:
+        raise Unauthorized()

--- a/src/config.py
+++ b/src/config.py
@@ -47,6 +47,7 @@ class BaseConfig:
     MAIL_PASSWORD = os.getenv("MAIL_PASSWORD")
     MAIL_DEFAULT_SENDER = os.getenv("MAIL_DEFAULT_SENDER")
     FRONTEND_URL = os.getenv("FRONTEND_URL", "https://knighthacks.org/")
+    BACKEND_URL = os.getenv("BACKEND_URL", "https://api.knighthacks.org/")
     BCRYPT_LOG_ROUNDS = 13
     TOKEN_EXPIRATION_MINUTES = 15
     TOKEN_EXPIRATION_SECONDS = 0

--- a/src/models/hacker.py
+++ b/src/models/hacker.py
@@ -12,6 +12,7 @@
 """
 from src import db
 from src.models.user import User
+from mongoengine import signals
 
 
 class HackerProfile(db.EmbeddedDocument):
@@ -29,3 +30,6 @@ class Hacker(User):  # Stored in the "user" collection
     current_status = db.BooleanField()
     hacker_profile = db.EmbeddedDocumentField(HackerProfile)
     isaccepted = db.BooleanField(default=False)
+
+
+signals.pre_delete.connect(User.pre_delete, sender=Hacker)

--- a/src/models/sponsor.py
+++ b/src/models/sponsor.py
@@ -11,6 +11,7 @@
 from mongoengine.errors import ValidationError
 from src import db
 from src.models.user import User
+from mongoengine import signals
 
 
 class Sponsor(User):
@@ -37,3 +38,6 @@ class Sponsor(User):
             pass
 
         return data
+
+
+signals.pre_delete.connect(User.pre_delete, sender=Sponsor)

--- a/src/models/tokenblacklist.py
+++ b/src/models/tokenblacklist.py
@@ -4,7 +4,6 @@
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 """
-from flask import current_app
 from src import db
 from src.models import BaseDocument
 from datetime import datetime
@@ -17,14 +16,4 @@ class TokenBlacklist(BaseDocument):
     from src.models.user import User
     user = db.ReferenceField(User, required=True)
 
-    meta = {
-        "indexes": [
-            {
-                "fields": ["created_at"],
-                "expireAfterSeconds": (
-                    60 * current_app.config.get("TOKEN_EXPIRATION_MINUTES")
-                    + current_app.config.get("TOKEN_EXPIRATION_SECONDS")
-                )
-            }
-        ]
-    }
+    meta = {"indexes": []}

--- a/src/models/tokenblacklist.py
+++ b/src/models/tokenblacklist.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""
+    server.models.tokenblacklist
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+"""
+from flask import current_app
+from src import db
+from src.models import BaseDocument
+from datetime import datetime
+
+
+class TokenBlacklist(BaseDocument):
+    jti = db.StringField(max_length=36, required=True, unique=True)
+    created_at = db.DateTimeField(required=True, default=datetime.utcnow)
+    revoked = db.BooleanField(default=False, required=True)
+    from src.models.user import User
+    user = db.ReferenceField(User, required=True)
+
+    meta = {
+        "indexes": [
+            {
+                "fields": ["created_at"],
+                "expireAfterSeconds": (
+                    60 * current_app.config.get("TOKEN_EXPIRATION_MINUTES")
+                    + current_app.config.get("TOKEN_EXPIRATION_SECONDS")
+                )
+            }
+        ]
+    }

--- a/src/models/user.py
+++ b/src/models/user.py
@@ -13,12 +13,11 @@
         ROLES
 
 """
-import jwt
-from flask import current_app
+from src.common.jwt import encode_jwt, decode_jwt
+from flask import current_app as app
 from datetime import datetime, timedelta
 from src import db, bcrypt
 from src.models import BaseDocument
-from werkzeug.exceptions import Unauthorized
 from enum import Flag, auto
 from mongoengine import signals
 
@@ -58,54 +57,40 @@ class User(BaseDocument):
     def pre_delete(cls, sender, document, **kwargs):
         from src.models.tokenblacklist import TokenBlacklist
         TokenBlacklist.objects(user=document).delete()
-        current_app.logger.info("Deleted all tokens from tokenblacklist for "
-                                f"the deleted user {document.username}.")
+        app.logger.info("Deleted all tokens from tokenblacklist for "
+                        f"the deleted user {document.username}.")
 
     def encode_auth_token(self) -> str:
         """Encode the auth token"""
-        payload = {
-            "exp": datetime.now() + timedelta(
-                minutes=current_app.config["TOKEN_EXPIRATION_MINUTES"],
-                seconds=current_app.config["TOKEN_EXPIRATION_SECONDS"]),
-            "iat": datetime.now(),
-            "sub": self.username
-        }
 
-        return jwt.encode(
-            payload,
-            current_app.config.get("SECRET_KEY"),
-            algorithm="HS256"
+        return encode_jwt(
+            exp=(
+                datetime.utcnow() + timedelta(
+                    minutes=app.config["TOKEN_EXPIRATION_MINUTES"],
+                    seconds=app.config["TOKEN_EXPIRATION_SECONDS"]
+                )
+            ),
+            sub=self.username
         )
 
     @staticmethod
     def decode_auth_token(auth_token: str) -> str:
         """Decode the auth token"""
-        try:
-            payload = jwt.decode(auth_token,
-                                 current_app.config.get("SECRET_KEY"),
-                                 algorithms=["HS256"])
-            return payload["sub"]
-        except jwt.ExpiredSignatureError:
-            raise Unauthorized()
-        except jwt.InvalidTokenError:
-            raise Unauthorized()
+        return decode_jwt(auth_token)["sub"]
 
     def encode_email_token(self) -> str:
         """Encode the email token"""
-        payload = {
-            "exp": datetime.now() + timedelta(
-                minutes=current_app.config["TOKEN_EMAIL_EXPIRATION_MINUTES"],
-                seconds=current_app.config["TOKEN_EMAIL_EXPIRATION_SECONDS"]),
-            "iat": datetime.now(),
-            "sub": self.username
-        }
-        email_token = jwt.encode(
-            payload,
-            current_app.config.get("SECRET_KEY"),
-            algorithm="HS256"
+        email_token = encode_jwt(
+            exp=(
+                datetime.utcnow() + timedelta(
+                    minutes=app.config["TOKEN_EMAIL_EXPIRATION_MINUTES"],
+                    seconds=app.config["TOKEN_EMAIL_EXPIRATION_SECONDS"]
+                )
+            ),
+            sub=self.username
         )
 
-        conf = current_app.config["BCRYPT_LOG_ROUNDS"]
+        conf = app.config["BCRYPT_LOG_ROUNDS"]
         email_token_hash = bcrypt.generate_password_hash(email_token, conf)
 
         self.modify(set__email_token_hash=email_token_hash)
@@ -116,18 +101,10 @@ class User(BaseDocument):
     @staticmethod
     def decode_email_token(email_token: str) -> str:
         """Decodes the email token"""
-        try:
-            payload = jwt.decode(email_token,
-                                 current_app.config.get("SECRET_KEY"),
-                                 algorithms=["HS256"])
-            return payload["sub"]
-        except jwt.ExpiredSignatureError:
-            raise Unauthorized()
-        except jwt.InvalidTokenError:
-            raise Unauthorized()
+        return decode_jwt(email_token)["sub"]
 
     def __init__(self, *args, **kwargs):
-        conf = current_app.config["BCRYPT_LOG_ROUNDS"]
+        conf = app.config["BCRYPT_LOG_ROUNDS"]
         if (kwargs.get("password") is not None
                 and isinstance(kwargs.get('password'), str)):
             kwargs['password'] = bcrypt.generate_password_hash(

--- a/tests/base.py
+++ b/tests/base.py
@@ -4,6 +4,8 @@ from flask_testing import TestCase
 from mongoengine import connect
 from mongoengine.connection import disconnect_all
 from src.models.user import User, ROLES
+from src.models.tokenblacklist import TokenBlacklist
+from src.common.jwt import decode_jwt
 
 os.environ["APP_SETTINGS"] = "src.config.TestingConfig"
 from src import app
@@ -28,14 +30,34 @@ class BaseTestCase(TestCase):
     def tearDown(self):
         self._conn.drop_database("mongoenginetest")
 
+    def login_as(self, user: User, password: str) -> str:
+        login = self.client.post(
+            "/api/auth/login/",
+            data=json.dumps({
+                "username": user.username,
+                "password": password
+            }),
+            content_type="application/json"
+        )
+
+        return login.headers["Set-Cookie"][4:-8]
+
     def login_user(self, roles: ROLES):
         user = User.createOne(
             username="tester",
             email="tester@localhost.dev",
             password="123456",
-            roles=roles,
+            roles=roles
         )
 
         token = user.encode_auth_token()
+
+        decoded_token = decode_jwt(token)
+
+        """ Add token to Token Blacklist as a non-revoked token """
+        TokenBlacklist.createOne(
+            jti=decoded_token["jti"],
+            user=user
+        )
 
         return token

--- a/tests/models/test_hacker_model.py
+++ b/tests/models/test_hacker_model.py
@@ -2,6 +2,7 @@
 from mongoengine.errors import NotUniqueError
 from src.models.hacker import Hacker
 from src.models.user import User, ROLES
+from src.models.tokenblacklist import TokenBlacklist
 from tests.base import BaseTestCase
 
 
@@ -20,3 +21,20 @@ class TestHackerModel(BaseTestCase):
         self.assertEqual(hacker.username, "foobar")
         self.assertEqual(hacker.email, "foobar@email.com")
         self.assertTrue(hacker.password)
+
+    def test_delete_tokenblacklist(self):
+        hacker = Hacker.createOne(
+            username="foobar",
+            email="foobar@email.com",
+            password="password",
+            roles=ROLES.HACKER,
+        )
+
+        self.login_as(hacker, password="password")
+
+        self.assertEqual(TokenBlacklist.objects.count(), 1)
+
+        hacker.delete()
+
+        self.assertEqual(Hacker.objects.count(), 0)
+        self.assertEqual(TokenBlacklist.objects.count(), 0)

--- a/tests/models/test_sponsor_model.py
+++ b/tests/models/test_sponsor_model.py
@@ -2,6 +2,7 @@
 from mongoengine.errors import NotUniqueError, ValidationError
 from src.models.sponsor import Sponsor
 from src.models.user import ROLES
+from src.models.tokenblacklist import TokenBlacklist
 from tests.base import BaseTestCase
 
 
@@ -20,3 +21,20 @@ class TestSponsorModel(BaseTestCase):
         self.assertEqual(sponsor.username, "foobar")
         self.assertEqual(sponsor.email, "foobar@email.com")
         self.assertTrue(sponsor.password)
+
+    def test_delete_tokenblacklist(self):
+        sponsor = Sponsor.createOne(
+            username="foobar",
+            email="foobar@email.com",
+            password="password",
+            roles=ROLES.SPONSOR,
+        )
+
+        self.login_as(sponsor, password="password")
+
+        self.assertEqual(TokenBlacklist.objects.count(), 1)
+
+        sponsor.delete()
+
+        self.assertEqual(Sponsor.objects.count(), 0)
+        self.assertEqual(TokenBlacklist.objects.count(), 0)

--- a/tests/routes/test_hackers.py
+++ b/tests/routes/test_hackers.py
@@ -133,7 +133,7 @@ class TestHackersBlueprint(BaseTestCase):
             roles=ROLES.HACKER,
         )
 
-        token = hacker.encode_auth_token()
+        token = self.login_as(hacker, password="123456")
 
         res = self.client.delete("/api/hackers/foobar/", headers=[("sid", token)])
 

--- a/tests/routes/test_sponsor.py
+++ b/tests/routes/test_sponsor.py
@@ -143,7 +143,7 @@ class TestSponsorsBlueprint(BaseTestCase):
             roles=ROLES.SPONSOR,
         )
 
-        token = sponsor.encode_auth_token()
+        token = self.login_as(sponsor, password="123456")
 
         res = self.client.delete(
             "/api/sponsors/delete_sponsor/foobar/", headers=[("sid", token)]


### PR DESCRIPTION
## Issue

If a session token has not expired, it can be used even after the user has logged out. The server should revoke the session token after the user logs out.

## Changes

- JWT tokens now use `iss` and `jti` claims.
- Nonexpired session tokens are stored in a `tokenblacklist` collection and are automatically removed from the collection when they expire.
- Session tokens are marked as `revoked` in the `tokenblacklist` collection when the user signs out.
- `@authenticate` ensures that the session token used is not revoked.