### PR TITLE
Handling invalid JSON better

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Types of Changes:
 
 - Fixed the url given in verification emails to link directly to backend api.
 - Failing test cases due to unauthorized routes requiring authorization.
+- JSONDecodeError is now handled and raises a 400 with an appropriate message.
 
 ### Added
 

--- a/src/api/hackers.py
+++ b/src/api/hackers.py
@@ -19,6 +19,7 @@ from werkzeug.exceptions import (
 )
 from src.models.hacker import Hacker
 from src.common.decorators import authenticate
+from json import JSONDecodeError
 
 
 hackers_blueprint = Blueprint("hackers", __name__)
@@ -60,7 +61,11 @@ def create_hacker():
         5XX:
             description: Unexpected error.
     """
-    data = json.loads(request.form.get("hacker", "{}"))
+    try:
+        data = json.loads(request.form.get("hacker"))
+    except JSONDecodeError:
+        raise BadRequest("Invalid JSON sent in hacker form part.")
+
     resume = None
 
     if "date" in data:

--- a/tests/routes/test_hackers.py
+++ b/tests/routes/test_hackers.py
@@ -28,7 +28,7 @@ class TestHackersBlueprint(BaseTestCase):
 
     def test_create_hacker_invalid_json(self):
         res = self.client.post(
-            "/api/hackers/", data={"hacker": json.dumps({})}, content_type="multipart/form-data"
+            "/api/hackers/", data={"hacker": ""}, content_type="multipart/form-data"
         )
 
         data = json.loads(res.data.decode())

--- a/tests/routes/test_hackers.py
+++ b/tests/routes/test_hackers.py
@@ -65,10 +65,10 @@ class TestHackersBlueprint(BaseTestCase):
     def test_create_hacker_invalid_datatypes(self):
         res = self.client.post(
             "/api/hackers/",
-            data=json.dumps(
+            data={"hacker": json.dumps(
                 {"email": "notanemail"}
-            ),
-            content_type="application/json",
+            )},
+            content_type="multipart/form-data",
         )
 
         data = json.loads(res.data.decode())


### PR DESCRIPTION
# Resolves #20 

- Invalid JSON will return a `404`