### PR TITLE
Fixed failing test cases due to certain endpoints now requiring authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Types of Changes:
 
 ## [Unreleased]
 
+### Fixed
+
+- Failing test cases due to unauthorized routes requiring authorization.
+
 ## [0.0.4] - 2021-09-09
 
 ### Fixed

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,5 +1,5 @@
 # flake8: noqa
-import os, json
+import os
 from flask_testing import TestCase
 from mongoengine import connect
 from mongoengine.connection import disconnect_all
@@ -27,3 +27,13 @@ class BaseTestCase(TestCase):
 
     def tearDown(self):
         self._conn.drop_database("mongoenginetest")
+
+    def login_user(self) -> str:
+        user = User.createOne(
+            username="test",
+            password="test"
+        )
+
+        token = user.encode_auth_token()
+
+        return token

--- a/tests/routes/test_events.py
+++ b/tests/routes/test_events.py
@@ -1,7 +1,6 @@
 # flake8: noqa
 import json
 from src.models.event import Event
-from src.models.user import User
 from tests.base import BaseTestCase
 from datetime import datetime
 
@@ -25,13 +24,16 @@ class TestEventsBlueprint(BaseTestCase):
                 "attendees_count": 10,
                 "event_status": "status"
             }),
-            content_type="application/json")
+            content_type="application/json",
+            headers=[("sid", self.login_user())])
 
         self.assertEqual(res.status_code, 201)
         self.assertEqual(Event.objects.count(), 1)
 
     def test_create_event_invalid_json(self):
-        res = self.client.post("/api/events/create_event/", data=json.dumps({}))
+        res = self.client.post("/api/events/create_event/",
+                               data=json.dumps({}),
+                               headers=[("sid", self.login_user())])
 
         data = json.loads(res.data.decode())
 
@@ -40,6 +42,8 @@ class TestEventsBlueprint(BaseTestCase):
 
     def test_create_event_invalid_datatypes(self):
         now = datetime.now()
+        token = self.login_user()
+
         res = self.client.post(
             "api/events/create_event/",
             data=json.dumps({
@@ -52,7 +56,8 @@ class TestEventsBlueprint(BaseTestCase):
                 "attendees_count": "newcount",
                 "event_status": 12345
             }),
-            content_type="application/json")
+            content_type="application/json",
+            headers=[("sid", token)])
         
         data = json.loads(res.data.decode())
 
@@ -71,7 +76,8 @@ class TestEventsBlueprint(BaseTestCase):
                 "attendees_count": "newcount",
                 "event_status": 12345
             }),
-            content_type="application/json")
+            content_type="application/json",
+            headers=[("sid", token)])
         
         data = json.loads(res.data.decode())
 
@@ -102,7 +108,8 @@ class TestEventsBlueprint(BaseTestCase):
                 "attendees_count": 10,
                 "event_status": "status"
             }),
-            content_type="application/json")
+            content_type="application/json",
+            headers=[("sid", self.login_user())])
         
         data = json.loads(res.data.decode())
 
@@ -134,13 +141,15 @@ class TestEventsBlueprint(BaseTestCase):
                 "attendees_count": 20,
                 "event_status": "ongoing",
             }),
-            content_type="application/json")
+            content_type="application/json",
+            headers=[("sid", self.login_user())])
 
         self.assertEqual(res.status_code, 201)
         self.assertEqual(Event.objects.first().event_status, "ongoing")
 
     def test_update_event_invalid_json(self):
-        res = self.client.put("api/events/update_event/new_event/")
+        res = self.client.put("api/events/update_event/new_event/",
+                              headers=[("sid", self.login_user())])
 
         data = json.loads(res.data.decode())
 
@@ -149,6 +158,7 @@ class TestEventsBlueprint(BaseTestCase):
 
     def test_update_event_invalid_datatypes(self):
         now = datetime.now()
+        token = self.login_user()
 
         Event.createOne(name="new_event",
                         date_time=now.isoformat(),
@@ -170,7 +180,8 @@ class TestEventsBlueprint(BaseTestCase):
                 "attendees_count": 20,
                 "event_status": "ongoing",
             }),
-            content_type="application/json")
+            content_type="application/json",
+            headers=[("sid", token)])
         
         data = json.loads(res.data.decode())
 
@@ -188,7 +199,8 @@ class TestEventsBlueprint(BaseTestCase):
                 "attendees_count": 20,
                 "event_status": "ongoing",
             }),
-            content_type="application/json")
+            content_type="application/json",
+            headers=[("sid", token)])
         
         data = json.loads(res.data.decode())
 
@@ -201,7 +213,8 @@ class TestEventsBlueprint(BaseTestCase):
             data=json.dumps({
                 "description": "new description"
             }),
-            content_type="application/json")
+            content_type="application/json",
+            headers=[("sid", self.login_user())])
         
         data = json.loads(res.data.decode())
 

--- a/tests/routes/test_hackers.py
+++ b/tests/routes/test_hackers.py
@@ -87,7 +87,10 @@ class TestHackersBlueprint(BaseTestCase):
             email="foobar1@email.com",
         )
 
-        res = self.client.get("/api/hackers/get_all_hackers/")
+        token = self.login_user()
+
+        res = self.client.get("/api/hackers/get_all_hackers/", 
+                              headers=[("sid", token)])
 
         data = json.loads(res.data.decode())
 
@@ -97,7 +100,10 @@ class TestHackersBlueprint(BaseTestCase):
 
     
     def test_get_all_hackers_not_found(self):
-        res = self.client.get("/api/hackers/get_all_hackers/")
+        token = self.login_user()
+
+        res = self.client.get("/api/hackers/get_all_hackers/", 
+                              headers=[("sid", token)])
 
         data = json.loads(res.data.decode())
 


### PR DESCRIPTION
Fixes the failing test cases by logging in the test client and providing the api with the proper token. The test cases were failing because they previously didn't require authentication.

- fixes: #33 

<!--
Ensure each step in CONTRIBUTING.md is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add tests that demonstrate the correct behavior of the change. Tests should fail without the change.
- [x] Add or update the relevant docs.
- [x] Add an entry in `CHANGELOG.md` summarizing the change.
- [x] Run tests, with no tests failed.
