### PR TITLE
Added dietary_restrictions field to hacker model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Types of Changes:
 
 - Failing test cases due to unauthorized routes requiring authorization.
 
+### Added
+
+- Added `dietary_restrictions` field to Hacker model.
+
 ## [0.0.4] - 2021-09-09
 
 ### Fixed

--- a/src/models/hacker.py
+++ b/src/models/hacker.py
@@ -51,6 +51,7 @@ class Hacker(BaseDocument):  # Stored in the "user" collection
     why_attend = db.StringField(max_length=200)
     what_learn = db.ListField()
     in_person = db.BooleanField(default=False)
+    dietary_restrictions = db.StringField()
 
     email = db.EmailField(unique=True, required=True)
     date = db.DateTimeField(default=datetime.utcnow)

--- a/src/schemas.yml
+++ b/src/schemas.yml
@@ -56,6 +56,9 @@ Hacker:
     in_person:
       type: boolean
       description: Whether the hacker is present in-person or not
+    dietary_restrictions:
+      type: string
+      description: A user-written description of their dietary restrictions (if any).
 Sponsor:
   type: object
   properties:


### PR DESCRIPTION
<!--
Before opening a PR, open an issue describing what the PR will address. Follow the steps in CONTRIBUTING.md.

Replace this comment with a description of the change. Describe how it addresses the linked issue.
-->
Adds a string field labeled `dietary_restrictions` to the Hacker model as per the request detailed in #37.

- fixes: #37 

<!--
Ensure each step in CONTRIBUTING.md is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add or update the relevant docs.
- [x] Add an entry in `CHANGELOG.md` summarizing the change.
- [x] Run tests, with no tests failed.
