### PR TITLE
53/create hacker async resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Types of Changes:
 
 ## [Unreleased]
 
+# Deprecated
+
+- The use of `multipart/form-data` on the POST `/api/hackers/` endpoint.
+
 ### Added
 
 -   POST `/api/hackers/resume/` endpoint for uploading a hacker's resume before the hacker is actually created in the DB. Unattached resumes are deleted after 24 hours.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ Types of Changes:
 
 ## [Unreleased]
 
+### Added
+
+-   POST `/api/hackers/resume/` endpoint for uploading a hacker's resume before the hacker is actually created in the DB. Unattached resumes are deleted after 24 hours.
+-   Added the ability to upload the hacker document as a `application/json` while providing the optional `resume_id` value to attach a resume to a hacker document which is returned from the `/api/hackers/resume/` endpoint.
+
 ### Security
 
 -   Removed ability for user to provide redirect uri for email verification endpoint.

--- a/src/api/hackers.py
+++ b/src/api/hackers.py
@@ -141,15 +141,23 @@ def create_hacker():
                     type: object
                     properties:
                         hacker:
+                            deprecated: true
                             allOf:
                                 - $ref: '#/components/schemas/Hacker'
                                 - type: object
+                                  description: >
+                                    Deprecated,
+                                    do not use `multipart/form-data`,
+                                    use `application/json`
+                                    and upload the resume through the
+                                    `/api/hackers/resume/` POST endpoint.
                                   properties:
                                     isaccepted:
                                         readOnly: true
                                     rsvp_status:
                                         readOnly: true
                         resume:
+                             deprecated: true
                              type: string
                              format: binary
                 encoding:
@@ -243,6 +251,12 @@ def create_hacker():
         "status": "success",
         "message": "Hacker was created!"
     }
+
+    res = make_response(res)
+    res.headers["Deprecation"] = (
+        "The use of multipart/form-data is deprecated,"
+        " use `application/json` and upload the resume through the "
+        "/api/hackers/resume/ POST endpoint.")
 
     return res, 201
 

--- a/src/api/hackers.py
+++ b/src/api/hackers.py
@@ -8,7 +8,7 @@
         create_hacker()
 
 """
-from flask import request, make_response, json
+from flask import request, make_response, json, current_app as app
 from src.api import Blueprint
 from mongoengine.errors import NotUniqueError, ValidationError
 from werkzeug.exceptions import (
@@ -179,7 +179,7 @@ def create_hacker():
         5XX:
             description: Unexpected error.
     """
-    if request.content_type == "multipart/form-data":
+    if "multipart/form-data" in request.content_type:
         try:
             data = json.loads(request.form.get("hacker"))
         except JSONDecodeError:
@@ -188,6 +188,7 @@ def create_hacker():
         data = request.get_json()
     else:
         raise UnsupportedMediaType()
+
 
     resume = None
 
@@ -252,11 +253,12 @@ def create_hacker():
         "message": "Hacker was created!"
     }
 
-    res = make_response(res)
-    res.headers["Deprecation"] = (
-        "The use of multipart/form-data is deprecated,"
-        " use `application/json` and upload the resume through the "
-        "/api/hackers/resume/ POST endpoint.")
+    if "multipart/form-data" in request.content_type:
+        res = make_response(res)
+        res.headers["Deprecation"] = (
+            "The use of multipart/form-data is deprecated,"
+            " use `application/json` and upload the resume through the "
+            "/api/hackers/resume/ POST endpoint.")
 
     return res, 201
 

--- a/src/api/hackers.py
+++ b/src/api/hackers.py
@@ -8,7 +8,7 @@
         create_hacker()
 
 """
-from flask import request, make_response, json, current_app as app
+from flask import request, make_response, json
 from src.api import Blueprint
 from mongoengine.errors import NotUniqueError, ValidationError
 from werkzeug.exceptions import (

--- a/src/models/resume.py
+++ b/src/models/resume.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+    src.models.resume
+    ~~~~~~~~~~~~~~~~~
+
+"""
+from src import db
+from src.models import BaseDocument
+from datetime import datetime
+
+
+class Resume(BaseDocument):
+    file = db.FileField(required=True)
+    attached = db.BooleanField(default=False)
+    created = db.DateTimeField(default=datetime.utcnow)
+    meta = {
+        "indexes": [
+            {
+                "fields": ["created"],
+                "expireAfterSeconds": 86400,  # Expires after 24 hours
+                "partialFilterExpression": {
+                    "attached": False
+                }
+            }
+        ]
+    }


### PR DESCRIPTION
<!--
Before opening a PR, open an issue describing what the PR will address. Follow the steps in CONTRIBUTING.md.

Replace this comment with a description of the change. Describe how it addresses the linked issue.
-->
Implements openapi specs as defined in #53 and deprecates previous method of creating hackers.

- fixes: #53 

<!--
Ensure each step in CONTRIBUTING.md is complete by adding an "x" to each box below.

If only docs were changed, these aren't relevant and can be removed.
-->

Checklist:

- [x] Add or update the relevant docs.
- [x] Add an entry in `CHANGELOG.md` summarizing the change.
- [x] Run tests, with no tests failed.
